### PR TITLE
[FEATURE] Add support for PHP 8.0

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,10 +9,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [7.2, 7.3, 7.4]
-        typo3-version: [9.5, 10.4]
+        php-version: [7.4, 7.3, 7.2]
+        typo3-version: [11.0, 10.4, 9.5]
         include:
-          - php-version: 7.4
+          - php-version: 8.0
             typo3-version: 11.0
             coverage: true
     services:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,10 +10,12 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [7.4, 7.3, 7.2]
-        typo3-version: [11.0, 10.4, 9.5]
+        typo3-version: [10.4, 9.5]
         include:
+          - php-version: 7.4
+            typo3-version: 11.4
           - php-version: 8.0
-            typo3-version: 11.0
+            typo3-version: 11.4
             coverage: true
     services:
       mysql:

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Automatically authenticates a TYPO3 CMS back end user for development",
     "type": "library",
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ~8.0",
         "typo3/cms-core": "~9.5 || ~10.4 || ~11.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR adds support for PHP 8.0 and includes latest TYPO3 11.4 into test workflow.