### PR TITLE
[BUGFIX] Bypass MFA during BE user authentication

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.1
-          tools: composer:v2, composer-require-checker, composer-unused
+          tools: composer:v2, composer-require-checker, composer-unused:0.7
           coverage: none
 
       # Validation

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.build
-/var
 /build/log
+/config
+/var
 /composer.lock
 .phpunit.result.cache
 .php-cs-fixer.cache

--- a/src/Service/AutomaticAuthenticationService.php
+++ b/src/Service/AutomaticAuthenticationService.php
@@ -36,7 +36,18 @@ class AutomaticAuthenticationService extends AbstractAuthenticationService
             return false;
         }
 
-        return $this->fetchUserRecord(getenv(self::TYPO3_AUTOLOGIN_USERNAME_ENVVAR));
+        $user = $this->fetchUserRecord(getenv(self::TYPO3_AUTOLOGIN_USERNAME_ENVVAR));
+
+        // Early return if user record is invalid
+        if (!is_array($user)) {
+            return false;
+        }
+
+        // Bypass MFA for current user
+        $this->pObj->getSession()->set('mfa', true);
+        $user['mfa'] = null;
+
+        return $user;
     }
 
     public function authUser(): int

--- a/tests/Functional/Service/AutomaticAuthenticationServiceTest.php
+++ b/tests/Functional/Service/AutomaticAuthenticationServiceTest.php
@@ -78,6 +78,34 @@ class AutomaticAuthenticationServiceTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function getUserReturnsFalseIfConfiguredUserDoesNotExist(): void
+    {
+        // Configure invalid user for automatic login
+        putenv(AutomaticAuthenticationService::TYPO3_AUTOLOGIN_USERNAME_ENVVAR . '=invalid');
+
+        // Make sure switch user functionality is disabled
+        $this->backendUser->getSession()->set('backuserid', 0);
+
+        self::assertFalse($this->subject->getUser());
+    }
+
+    /**
+     * @test
+     */
+    public function getUserBypassesMFA(): void
+    {
+        self::assertNotTrue($this->backendUser->getSession()->get('mfa'));
+
+        $actual = $this->subject->getUser();
+
+        self::assertIsArray($actual);
+        self::assertNull($actual['mfa']);
+        self::assertTrue($this->backendUser->getSession()->get('mfa'));
+    }
+
+    /**
+     * @test
+     */
     public function authUserReturnsCorrectAuthenticationState(): void
     {
         self::assertEquals(200, $this->subject->authUser());


### PR DESCRIPTION
TYPO3 11 introduced MFA support for backend logins. With this PR, a configured MFA is now bypassed for the configured user during authentication.