### PR TITLE
[!!!][FEATURE] Modernize library and require at least PHP 8.0 & TYPO3 11.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,47 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# TS/JS-Files
+[*.{ts,js}]
+indent_size = 2
+
+# JSON-Files
+[*.json]
+indent_style = tab
+
+# YAML-Files
+[*.{yaml,yml}]
+indent_size = 2
+
+# NEON-Files
+[*.neon]
+indent_size = 2
+indent_style = tab
+
+# TypoScript
+[*.{typoscript,tsconfig}]
+indent_size = 2
+
+# XLF-Files
+[*.xlf]
+indent_style = tab
+
+# SQL-Files
+[*.sql]
+indent_style = tab
+indent_size = 2
+
+# .htaccess
+[{_.htaccess,.htaccess}]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 /.github/ export-ignore
+/build/cgl/ export-ignore
 /build/tests/ export-ignore
 /tests/ export-ignore
 /.gitattributes export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,5 +2,6 @@
 /build/cgl/ export-ignore
 /build/tests/ export-ignore
 /tests/ export-ignore
+/.editorconfig export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore

--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -34,7 +34,7 @@ jobs:
 
       # Check Composer dependencies
       - name: Check dependencies
-        run: composer-require-checker check --config-file dependency-checker.json
+        run: composer-require-checker check
       - run: composer install --no-progress
       - name: Check for unused dependencies
         run: composer-unused

--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -1,0 +1,52 @@
+name: CGL
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  cgl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      # Prepare environment
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.1
+          tools: composer:v2, composer-require-checker, composer-unused
+          coverage: none
+
+      # Validation
+      - name: Validate composer.json
+        run: composer validate --no-check-lock
+
+      # Install dependencies
+      - name: Install Composer dependencies
+        run: composer update --no-progress --no-plugins --no-scripts
+
+      # Check Composer dependencies
+      - name: Check dependencies
+        run: composer-require-checker check --config-file dependency-checker.json
+      - run: composer install --no-progress
+      - name: Check for unused dependencies
+        run: composer-unused
+
+      # Linting
+      - name: Lint composer.json
+        run: composer lint:composer -- --dry-run
+      - name: Lint .editorconfig
+        run: .build/bin/ec
+      - name: Lint PHP
+        run: composer lint:php -- --dry-run
+
+      # Migration
+      - name: Run Rector migration
+        run: composer migration:rector -- --dry-run

--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -47,6 +47,10 @@ jobs:
       - name: Lint PHP
         run: composer lint:php -- --dry-run
 
+      # SCA
+      - name: SCA PHP
+        run: composer sca:php -- --error-format github
+
       # Migration
       - name: Run Rector migration
         run: composer migration:rector -- --dry-run

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,12 @@
 name: Tests
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   tests:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,42 +3,17 @@ on: [push, pull_request]
 
 jobs:
   tests:
-    name: PHP ${{ matrix.php-version }} & TYPO3 ${{ matrix.typo3-version }}
-
+    name: Tests (PHP ${{ matrix.php-version }}, TYPO3 ${{ matrix.typo3-version }} & ${{ matrix.dependencies }} dependencies)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # TYPO3 9.5
-          - php-version: "7.2"
-            typo3-version: "9.5"
-          - php-version: "7.3"
-            typo3-version: "9.5"
-          - php-version: "7.4"
-            typo3-version: "9.5"
-          # TYPO3 10.4
-          - php-version: "7.2"
-            typo3-version: "10.4"
-          - php-version: "7.3"
-            typo3-version: "10.4"
-          - php-version: "7.4"
-            typo3-version: "10.4"
-          # TYPO3 11.5
-          - php-version: "7.4"
-            typo3-version: "11.5"
+        php-version: ["8.0", "8.1", "8.2"]
+        typo3-version: ["11.5", "12.1"]
+        dependencies: ["highest", "lowest"]
+        exclude:
           - php-version: "8.0"
-            typo3-version: "11.5"
-          - php-version: "8.1"
-            typo3-version: "11.5"
-          - php-version: "8.2"
-            typo3-version: "11.5"
-          # TYPO3 12.0
-          - php-version: "8.1"
-            typo3-version: "12.0"
-          - php-version: "8.2"
-            typo3-version: "12.0"
-            coverage: true
+            typo3-version: "12.1"
     services:
       mysql:
         image: mysql:5.7
@@ -47,9 +22,10 @@ jobs:
           MYSQL_DATABASE: typo3
         ports:
           - 3306
-
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       # Prepare environment
       - name: Setup PHP
@@ -57,14 +33,52 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: none
 
       # Install Composer dependencies
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
         with:
-          dependency-versions: "highest"
-          composer-options: "--with=typo3/cms-core:~${{ matrix.typo3-version }}"
+          dependency-versions: ${{ matrix.dependencies }}
+          composer-options: "--with=typo3/cms-core:^${{ matrix.typo3-version }}"
+
+      # Run tests
+      - name: Run tests
+        run: composer test
+        env:
+          typo3DatabaseName: typo3
+          typo3DatabaseHost: 127.0.0.1
+          typo3DatabasePort: ${{ job.services.mysql.ports[3306] }}
+          typo3DatabaseUsername: root
+          typo3DatabasePassword: root
+
+  coverage:
+    name: Test coverage
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: typo3
+        ports:
+          - 3306
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # Prepare environment
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          tools: composer:v2
+          coverage: pcov
+
+      # Install Composer dependencies
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v2
 
       # Run tests
       - name: Run tests
@@ -81,4 +95,3 @@ jobs:
         run: composer test:coverage
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: matrix.coverage

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /build/log
 /composer.lock
 .phpunit.result.cache
+.php-cs-fixer.cache

--- a/Readme.md
+++ b/Readme.md
@@ -5,14 +5,14 @@
 
 ## What does it do?
 
-This package automatically starts a backend user session for the open source CMS 
+This package automatically starts a backend user session for the open source CMS
 [TYPO3](https://typo3.org), configured by an environment variable. You can set
 a cookie to temporarily disable the automatic login. There‘s a [bookmarklet](#bookmarklet)
 that does the job for you.
 
-It is based on the Daniel Siepmann‘s 
+It is based on the Daniel Siepmann‘s
 [great work](https://daniel-siepmann.de/Posts/2018/2018-07-25-auto-login-typo3-backend.html).
-If you feel like saying "Thank you" or donating please consider him first! 
+If you feel like saying "Thank you" or donating please consider him first!
 
 ## Warning
 
@@ -34,11 +34,11 @@ composer require --dev undkonsorten/typo3-auto-login
 ```
 
 Usage without composer has not been tested but might be perfectly possible
-if you take care about class (auto) loading by yourself. 
+if you take care about class (auto) loading by yourself.
 
 ## Usage
 
-To configure username for automatic login set the environment variable 
+To configure username for automatic login set the environment variable
 `$TYPO3_AUTOLOGIN_USERNAME` somewhere in your environment.
 
 Add an initialization call in your `AdditionalConfiguration.php` or in
@@ -48,7 +48,7 @@ it to a file only loaded in `Development` context.
 
 ```php
 if (\TYPO3\CMS\Core\Core\Environment::getContext()->isDevelopment()) {
-    \Undkonsorten\TYPO3AutoLogin\Utility\RegisterServiceUtility::registerAutomaticAuthenticationService();   
+    \Undkonsorten\TYPO3AutoLogin\Utility\RegisterServiceUtility::registerAutomaticAuthenticationService();
 }
 ```
 

--- a/build/bookmarklet.js
+++ b/build/bookmarklet.js
@@ -11,12 +11,12 @@
 
 //javascript:
 (q=>{
-	let n=window.Notification,
-		s='_typo3-auto-login',
-		d='disable',
-		p='TYPO3 auto login',
-		w=document,
-		a=w.cookie.split(';').some(x=>x.trim()===`${s}=${d}`);
-	w.cookie=`${s}=${a?';expires='+new Date(0).toUTCString():d};path=/;`;
-	n&&n.permission!=='denied'&&n.requestPermission().then(q=>new n(p,{body:`(${a?'✓':'✗'}) ${p} is now ${a ? 'enabled' : 'disabled'}. Cookie »${s}« has been ${a?'removed':'set'}.`,icon:'https://extensions.typo3.org/fileadmin/user_upload/ext_icon.png'}));
+  let n=window.Notification,
+    s='_typo3-auto-login',
+    d='disable',
+    p='TYPO3 auto login',
+    w=document,
+    a=w.cookie.split(';').some(x=>x.trim()===`${s}=${d}`);
+  w.cookie=`${s}=${a?';expires='+new Date(0).toUTCString():d};path=/;`;
+  n&&n.permission!=='denied'&&n.requestPermission().then(q=>new n(p,{body:`(${a?'✓':'✗'}) ${p} is now ${a ? 'enabled' : 'disabled'}. Cookie »${s}« has been ${a?'removed':'set'}.`,icon:'https://extensions.typo3.org/fileadmin/user_upload/ext_icon.png'}));
 })();

--- a/build/cgl/.php-cs-fixer.php
+++ b/build/cgl/.php-cs-fixer.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use TYPO3\CodingStandards\CsFixerConfig;
+
+$config = CsFixerConfig::create();
+$config->getFinder()
+    ->in(dirname(__DIR__, 2))
+    ->ignoreVCSIgnored(true)
+;
+
+return $config;

--- a/build/cgl/phpstan.neon
+++ b/build/cgl/phpstan.neon
@@ -1,0 +1,11 @@
+includes:
+	- ../../.build/vendor/phpstan/phpstan/conf/bleedingEdge.neon
+parameters:
+	level: max
+	bootstrapFiles:
+		- ../../.build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php
+	paths:
+		- ../../src
+		- ../../tests
+	stubFiles:
+		- ../../tests/Stubs/AbstractAuthenticationService.stub

--- a/build/cgl/rector.php
+++ b/build/cgl/rector.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector;
+use Rector\Set\ValueObject\LevelSetList;
+use Ssch\TYPO3Rector\Set\Typo3SetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        getcwd() . '/src',
+        getcwd() . '/tests',
+    ]);
+
+    $rectorConfig->skip([
+        AddLiteralSeparatorToNumberRector::class,
+    ]);
+
+    $rectorConfig->sets([
+        LevelSetList::UP_TO_PHP_80,
+        Typo3SetList::TYPO3_11,
+    ]);
+};

--- a/build/tests/functional.xml
+++ b/build/tests/functional.xml
@@ -1,30 +1,22 @@
-<phpunit
-        backupGlobals="true"
-        bootstrap="../../.build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTestsBootstrap.php"
-        colors="true"
-        convertErrorsToExceptions="true"
-        convertWarningsToExceptions="true"
-        forceCoversAnnotation="false"
-        processIsolation="false"
-        stopOnError="false"
-        stopOnFailure="false"
-        stopOnIncomplete="false"
-        stopOnSkipped="false"
-        verbose="false"
-        beStrictAboutTestsThatDoNotTestAnything="true"
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="true"
+         bootstrap="../../.build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTestsBootstrap.php"
+         colors="true"
+         xsi:noNamespaceSchemaLocation="../../.build/vendor/phpunit/phpunit/phpunit.xsd"
 >
     <testsuites>
         <testsuite name="Functional tests">
             <directory>../../tests/Functional</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">../../src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="../../.build/log/coverage/html/functional" showUncoveredFiles="true" />
-        <log type="coverage-php" target="../../.build/log/coverage/clover/functional.cov" showUncoveredFiles="true" />
-    </logging>
+        </include>
+        <report>
+            <html outputDirectory="../../.build/log/coverage/html/functional"/>
+            <php outputFile="../../.build/log/coverage/clover/functional.cov"/>
+        </report>
+    </coverage>
 </phpunit>

--- a/build/tests/unit.xml
+++ b/build/tests/unit.xml
@@ -1,30 +1,22 @@
-<phpunit
-        backupGlobals="true"
-        bootstrap="../../.build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php"
-        colors="true"
-        convertErrorsToExceptions="true"
-        convertWarningsToExceptions="true"
-        forceCoversAnnotation="false"
-        processIsolation="false"
-        stopOnError="false"
-        stopOnFailure="false"
-        stopOnIncomplete="false"
-        stopOnSkipped="false"
-        verbose="false"
-        beStrictAboutTestsThatDoNotTestAnything="true"
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="true"
+         bootstrap="../../.build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php"
+         colors="true"
+         xsi:noNamespaceSchemaLocation="../../.build/vendor/phpunit/phpunit/phpunit.xsd"
 >
     <testsuites>
         <testsuite name="Unit tests">
             <directory>../../tests/Unit</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">../../src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="../../.build/log/coverage/html/unit" showUncoveredFiles="true" />
-        <log type="coverage-php" target="../../.build/log/coverage/clover/unit.cov" showUncoveredFiles="true" />
-    </logging>
+        </include>
+        <report>
+            <html outputDirectory="../../.build/log/coverage/html/unit"/>
+            <php outputFile="../../.build/log/coverage/clover/unit.cov"/>
+        </report>
+    </coverage>
 </phpunit>

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": "~8.0.0 || ~8.1.0 || ~8.2.0",
-		"typo3/cms-core": "^11.0 || ^12.0"
+		"typo3/cms-core": "^11.5.4 || ^12.0"
 	},
 	"require-dev": {
 		"armin/editorconfig-cli": "^1.5",

--- a/composer.json
+++ b/composer.json
@@ -1,27 +1,28 @@
 {
 	"name": "undkonsorten/typo3-auto-login",
 	"description": "Automatically authenticates a TYPO3 CMS back end user for development",
-	"type": "library",
-	"require": {
-		"php": "~8.0.0 || ~8.1.0 || ~8.2.0",
-		"typo3/cms-core": "^11.0 || ^12.0"
-	},
-	"require-dev": {
-		"typo3/testing-framework": "^7.0@dev",
-		"typo3/minimal": "^11.0 || ^12.0",
-		"phpunit/phpcov": "^8.0",
-		"php-coveralls/php-coveralls": "^2.2",
-		"ssch/typo3-rector": "^1.1",
-		"typo3/coding-standards": "^0.7",
-		"armin/editorconfig-cli": "^1.5"
-	},
 	"license": "GPL-2.0-or-later",
+	"type": "library",
 	"authors": [
 		{
 			"name": "Felix Althaus",
 			"email": "felix.althaus@undkonsorten.com"
 		}
 	],
+	"require": {
+		"php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+		"typo3/cms-core": "^11.0 || ^12.0"
+	},
+	"require-dev": {
+		"armin/editorconfig-cli": "^1.5",
+		"ergebnis/composer-normalize": "^2.29",
+		"php-coveralls/php-coveralls": "^2.2",
+		"phpunit/phpcov": "^8.0",
+		"ssch/typo3-rector": "^1.1",
+		"typo3/coding-standards": "^0.7",
+		"typo3/minimal": "^11.0 || ^12.0",
+		"typo3/testing-framework": "^7.0@dev"
+	},
 	"autoload": {
 		"psr-4": {
 			"Undkonsorten\\TYPO3AutoLogin\\": "src/"
@@ -32,17 +33,18 @@
 			"Undkonsorten\\TYPO3AutoLogin\\Tests\\": "tests/"
 		}
 	},
+	"config": {
+		"allow-plugins": {
+			"ergebnis/composer-normalize": true,
+			"typo3/class-alias-loader": true,
+			"typo3/cms-composer-installers": true
+		},
+		"bin-dir": ".build/bin",
+		"vendor-dir": ".build/vendor"
+	},
 	"extra": {
 		"typo3/cms": {
 			"web-dir": ".build/web"
-		}
-	},
-	"config": {
-		"vendor-dir": ".build/vendor",
-		"bin-dir": ".build/bin",
-		"allow-plugins": {
-			"typo3/class-alias-loader": true,
-			"typo3/cms-composer-installers": true
 		}
 	},
 	"scripts": {
@@ -57,9 +59,11 @@
 			"[ -d .build/web/typo3/sysext/install ] || ln -sfn ../../../vendor/typo3/cms-install .build/web/typo3/sysext/install"
 		],
 		"lint": [
+			"@lint:composer",
 			"@lint:editorconfig",
 			"@lint:php"
 		],
+		"lint:composer": "@composer normalize --no-check-lock --no-update-lock",
 		"lint:editorconfig": "ec --fix",
 		"lint:php": "php-cs-fixer fix --config build/cgl/.php-cs-fixer.php",
 		"migration": [
@@ -70,13 +74,13 @@
 			"@test:unit",
 			"@test:functional"
 		],
-		"test:unit": "phpunit -c build/tests/unit.xml",
-		"test:functional": "phpunit -c build/tests/functional.xml",
 		"test:coverage": [
 			"@test:coverage:merge",
 			"@test:coverage:coveralls"
 		],
+		"test:coverage:coveralls": "php-coveralls -x .build/log/coverage/clover.xml -o .build/log/coverage/coveralls.json -v",
 		"test:coverage:merge": "phpcov merge --clover .build/log/coverage/clover.xml .build/log/coverage/clover",
-		"test:coverage:coveralls": "php-coveralls -x .build/log/coverage/clover.xml -o .build/log/coverage/coveralls.json -v"
+		"test:functional": "phpunit -c build/tests/functional.xml",
+		"test:unit": "phpunit -c build/tests/unit.xml"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -3,13 +3,13 @@
     "description": "Automatically authenticates a TYPO3 CMS back end user for development",
     "type": "library",
     "require": {
-        "php": "^7.1 || ~8.0",
-        "typo3/cms-core": "~9.5 || ~10.4 || ~11.0 || ~12.0"
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+        "typo3/cms-core": "^11.0 || ^12.0"
     },
     "require-dev": {
-        "typo3/testing-framework": "^4.0 || ^5.0 || ^6.0 || ^7.0@dev",
-        "typo3/minimal": "~9.5 || ~10.4 || ~11.0 || ~12.0",
-        "phpunit/phpcov": "^5.0 || ^6.0 || ^7.0 || ^8.0",
+        "typo3/testing-framework": "^7.0@dev",
+        "typo3/minimal": "^11.0 || ^12.0",
+        "phpunit/phpcov": "^8.0",
         "php-coveralls/php-coveralls": "^2.2"
     },
     "license": "GPL-2.0-or-later",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,12 @@
 		"armin/editorconfig-cli": "^1.5",
 		"ergebnis/composer-normalize": "^2.29",
 		"php-coveralls/php-coveralls": "^2.2",
+		"phpstan/extension-installer": "^1.2",
+		"phpstan/phpstan": "^1.9",
+		"phpstan/phpstan-phpunit": "^1.3",
+		"phpstan/phpstan-strict-rules": "^1.4",
 		"phpunit/phpcov": "^8.0",
+		"saschaegerer/phpstan-typo3": "^1.8",
 		"ssch/typo3-rector": "^1.1",
 		"typo3/coding-standards": "^0.7",
 		"typo3/minimal": "^11.0 || ^12.0",
@@ -36,6 +41,7 @@
 	"config": {
 		"allow-plugins": {
 			"ergebnis/composer-normalize": true,
+			"phpstan/extension-installer": true,
 			"typo3/class-alias-loader": true,
 			"typo3/cms-composer-installers": true
 		},
@@ -71,6 +77,10 @@
 			"@migration:rector"
 		],
 		"migration:rector": "rector process -c build/cgl/rector.php",
+		"sca": [
+			"@sca:php"
+		],
+		"sca:php": "phpstan analyse -c build/cgl/phpstan.neon",
 		"test": [
 			"@test:unit",
 			"@test:functional"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "typo3/testing-framework": "^7.0@dev",
         "typo3/minimal": "^11.0 || ^12.0",
         "phpunit/phpcov": "^8.0",
-        "php-coveralls/php-coveralls": "^2.2"
+        "php-coveralls/php-coveralls": "^2.2",
+        "ssch/typo3-rector": "^1.1"
     },
     "license": "GPL-2.0-or-later",
     "authors": [
@@ -53,6 +54,10 @@
             "[ -d .build/web/typo3/sysext/frontend ] || ln -sfn ../../../vendor/typo3/cms-frontend .build/web/typo3/sysext/frontend",
             "[ -d .build/web/typo3/sysext/install ] || ln -sfn ../../../vendor/typo3/cms-install .build/web/typo3/sysext/install"
         ],
+        "migration": [
+            "@migration:rector"
+        ],
+        "migration:rector": "rector process -c build/cgl/rector.php",
         "test": [
             "@test:unit",
             "@test:functional"

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
 			"typo3/cms-composer-installers": true
 		},
 		"bin-dir": ".build/bin",
+		"sort-packages": true,
 		"vendor-dir": ".build/vendor"
 	},
 	"extra": {

--- a/composer.json
+++ b/composer.json
@@ -1,74 +1,82 @@
 {
-    "name": "undkonsorten/typo3-auto-login",
-    "description": "Automatically authenticates a TYPO3 CMS back end user for development",
-    "type": "library",
-    "require": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
-        "typo3/cms-core": "^11.0 || ^12.0"
-    },
-    "require-dev": {
-        "typo3/testing-framework": "^7.0@dev",
-        "typo3/minimal": "^11.0 || ^12.0",
-        "phpunit/phpcov": "^8.0",
-        "php-coveralls/php-coveralls": "^2.2",
-        "ssch/typo3-rector": "^1.1"
-    },
-    "license": "GPL-2.0-or-later",
-    "authors": [
-        {
-            "name": "Felix Althaus",
-            "email": "felix.althaus@undkonsorten.com"
-        }
-    ],
-    "autoload": {
-        "psr-4": {
-            "Undkonsorten\\TYPO3AutoLogin\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Undkonsorten\\TYPO3AutoLogin\\Tests\\": "tests/"
-        }
-    },
-    "extra": {
-        "typo3/cms": {
-            "web-dir": ".build/web"
-        }
-    },
-    "config": {
-        "vendor-dir": ".build/vendor",
-        "bin-dir": ".build/bin",
-        "allow-plugins": {
-            "typo3/class-alias-loader": true,
-            "typo3/cms-composer-installers": true
-        }
-    },
-    "scripts": {
-        "post-autoload-dump": [
-            "# The following lines can be removed once TF v7 is stable",
-            "mkdir -p .build/web/typo3/sysext",
-            "[ -d .build/web/typo3/sysext/backend ] || ln -sfn ../../../vendor/typo3/cms-backend .build/web/typo3/sysext/backend",
-            "[ -d .build/web/typo3/sysext/core ] || ln -sfn ../../../vendor/typo3/cms-core .build/web/typo3/sysext/core",
-            "[ -d .build/web/typo3/sysext/extbase ] || ln -sfn ../../../vendor/typo3/cms-extbase .build/web/typo3/sysext/extbase",
-            "[ -d .build/web/typo3/sysext/fluid ] || ln -sfn ../../../vendor/typo3/cms-fluid .build/web/typo3/sysext/fluid",
-            "[ -d .build/web/typo3/sysext/frontend ] || ln -sfn ../../../vendor/typo3/cms-frontend .build/web/typo3/sysext/frontend",
-            "[ -d .build/web/typo3/sysext/install ] || ln -sfn ../../../vendor/typo3/cms-install .build/web/typo3/sysext/install"
-        ],
-        "migration": [
-            "@migration:rector"
-        ],
-        "migration:rector": "rector process -c build/cgl/rector.php",
-        "test": [
-            "@test:unit",
-            "@test:functional"
-        ],
-        "test:unit": "phpunit -c build/tests/unit.xml",
-        "test:functional": "phpunit -c build/tests/functional.xml",
-        "test:coverage": [
-            "@test:coverage:merge",
-            "@test:coverage:coveralls"
-        ],
-        "test:coverage:merge": "phpcov merge --clover .build/log/coverage/clover.xml .build/log/coverage/clover",
-        "test:coverage:coveralls": "php-coveralls -x .build/log/coverage/clover.xml -o .build/log/coverage/coveralls.json -v"
-    }
+	"name": "undkonsorten/typo3-auto-login",
+	"description": "Automatically authenticates a TYPO3 CMS back end user for development",
+	"type": "library",
+	"require": {
+		"php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+		"typo3/cms-core": "^11.0 || ^12.0"
+	},
+	"require-dev": {
+		"typo3/testing-framework": "^7.0@dev",
+		"typo3/minimal": "^11.0 || ^12.0",
+		"phpunit/phpcov": "^8.0",
+		"php-coveralls/php-coveralls": "^2.2",
+		"ssch/typo3-rector": "^1.1",
+		"typo3/coding-standards": "^0.7",
+		"armin/editorconfig-cli": "^1.5"
+	},
+	"license": "GPL-2.0-or-later",
+	"authors": [
+		{
+			"name": "Felix Althaus",
+			"email": "felix.althaus@undkonsorten.com"
+		}
+	],
+	"autoload": {
+		"psr-4": {
+			"Undkonsorten\\TYPO3AutoLogin\\": "src/"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"Undkonsorten\\TYPO3AutoLogin\\Tests\\": "tests/"
+		}
+	},
+	"extra": {
+		"typo3/cms": {
+			"web-dir": ".build/web"
+		}
+	},
+	"config": {
+		"vendor-dir": ".build/vendor",
+		"bin-dir": ".build/bin",
+		"allow-plugins": {
+			"typo3/class-alias-loader": true,
+			"typo3/cms-composer-installers": true
+		}
+	},
+	"scripts": {
+		"post-autoload-dump": [
+			"# The following lines can be removed once TF v7 is stable",
+			"mkdir -p .build/web/typo3/sysext",
+			"[ -d .build/web/typo3/sysext/backend ] || ln -sfn ../../../vendor/typo3/cms-backend .build/web/typo3/sysext/backend",
+			"[ -d .build/web/typo3/sysext/core ] || ln -sfn ../../../vendor/typo3/cms-core .build/web/typo3/sysext/core",
+			"[ -d .build/web/typo3/sysext/extbase ] || ln -sfn ../../../vendor/typo3/cms-extbase .build/web/typo3/sysext/extbase",
+			"[ -d .build/web/typo3/sysext/fluid ] || ln -sfn ../../../vendor/typo3/cms-fluid .build/web/typo3/sysext/fluid",
+			"[ -d .build/web/typo3/sysext/frontend ] || ln -sfn ../../../vendor/typo3/cms-frontend .build/web/typo3/sysext/frontend",
+			"[ -d .build/web/typo3/sysext/install ] || ln -sfn ../../../vendor/typo3/cms-install .build/web/typo3/sysext/install"
+		],
+		"lint": [
+			"@lint:editorconfig",
+			"@lint:php"
+		],
+		"lint:editorconfig": "ec --fix",
+		"lint:php": "php-cs-fixer fix --config build/cgl/.php-cs-fixer.php",
+		"migration": [
+			"@migration:rector"
+		],
+		"migration:rector": "rector process -c build/cgl/rector.php",
+		"test": [
+			"@test:unit",
+			"@test:functional"
+		],
+		"test:unit": "phpunit -c build/tests/unit.xml",
+		"test:functional": "phpunit -c build/tests/functional.xml",
+		"test:coverage": [
+			"@test:coverage:merge",
+			"@test:coverage:coveralls"
+		],
+		"test:coverage:merge": "phpcov merge --clover .build/log/coverage/clover.xml .build/log/coverage/clover",
+		"test:coverage:coveralls": "php-coveralls -x .build/log/coverage/clover.xml -o .build/log/coverage/coveralls.json -v"
+	}
 }

--- a/src/Exception/NotAllowedException.php
+++ b/src/Exception/NotAllowedException.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Undkonsorten\TYPO3AutoLogin\Exception;
 
 /**

--- a/src/Service/AutomaticAuthenticationService.php
+++ b/src/Service/AutomaticAuthenticationService.php
@@ -32,17 +32,15 @@ class AutomaticAuthenticationService extends AbstractAuthenticationService
      */
     public function getUser(): array|false
     {
-        if ($this->isSwitchUserActive()) {
+        if ($this->isSwitchUserActive() || getenv(self::TYPO3_AUTOLOGIN_USERNAME_ENVVAR) === false) {
             return false;
         }
 
         return $this->fetchUserRecord(getenv(self::TYPO3_AUTOLOGIN_USERNAME_ENVVAR));
     }
 
-    public function authUser(
-        /** @noinspection PhpUnusedParameterInspection */
-        array $user
-    ): int {
+    public function authUser(): int
+    {
         return 200;
     }
 

--- a/src/Service/AutomaticAuthenticationService.php
+++ b/src/Service/AutomaticAuthenticationService.php
@@ -27,11 +27,15 @@ class AutomaticAuthenticationService extends AbstractAuthenticationService
      */
     public const TYPO3_AUTOLOGIN_USERNAME_ENVVAR = 'TYPO3_AUTOLOGIN_USERNAME';
 
-    public function getUser()
+    /**
+     * @return array<string, mixed>|false
+     */
+    public function getUser(): array|false
     {
         if ($this->isSwitchUserActive()) {
-            return null;
+            return false;
         }
+
         return $this->fetchUserRecord(getenv(self::TYPO3_AUTOLOGIN_USERNAME_ENVVAR));
     }
 

--- a/src/Service/AutomaticAuthenticationService.php
+++ b/src/Service/AutomaticAuthenticationService.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Undkonsorten\TYPO3AutoLogin\Service;
@@ -21,7 +22,6 @@ use TYPO3\CMS\Core\Authentication\AbstractAuthenticationService;
  */
 class AutomaticAuthenticationService extends AbstractAuthenticationService
 {
-
     /**
      * Name of the environment variable that defines the BE user name
      */

--- a/src/Service/AutomaticAuthenticationService.php
+++ b/src/Service/AutomaticAuthenticationService.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Undkonsorten\TYPO3AutoLogin\Service;
 
 use TYPO3\CMS\Core\Authentication\AbstractAuthenticationService;
-use TYPO3\CMS\Core\Information\Typo3Version;
 
 /**
  * This file is part of the composer package "undkonsorten/typo3-auto-login" for use with TYPO3 CMS.
@@ -45,15 +44,6 @@ class AutomaticAuthenticationService extends AbstractAuthenticationService
 
     private function isSwitchUserActive(): bool
     {
-        if ($this->usesNewSessionHandling()) {
-            return (bool)$this->pObj->getSession()->get('backuserid');
-        }
-
-        return (bool)($this->authInfo['userSession']['ses_backuserid'] ?? false);
-    }
-
-    private function usesNewSessionHandling(): bool
-    {
-        return (new Typo3Version())->getMajorVersion() >= 11;
+        return (bool)$this->pObj->getSession()->get('backuserid');
     }
 }

--- a/src/Utility/RegisterServiceUtility.php
+++ b/src/Utility/RegisterServiceUtility.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Undkonsorten\TYPO3AutoLogin\Utility;
@@ -28,7 +29,6 @@ use Undkonsorten\TYPO3AutoLogin\Service\AutomaticAuthenticationService;
  */
 class RegisterServiceUtility
 {
-
     /**
      * Name of the cookie that disables autologin
      */
@@ -47,7 +47,7 @@ class RegisterServiceUtility
         if (Environment::getContext()->isProduction()) {
             throw new NotAllowedException(sprintf('Automatic login is not allowed in Production context. Current context: "%s"', Environment::getContext()), 1534842728);
         }
-        if (false === getenv(AutomaticAuthenticationService::TYPO3_AUTOLOGIN_USERNAME_ENVVAR)) {
+        if (getenv(AutomaticAuthenticationService::TYPO3_AUTOLOGIN_USERNAME_ENVVAR) === false) {
             static::getLogger()->notice(sprintf(
                 '%s is enabled but no username given. Please set environment variable "%s".',
                 AutomaticAuthenticationService::class,

--- a/src/Utility/RegisterServiceUtility.php
+++ b/src/Utility/RegisterServiceUtility.php
@@ -70,9 +70,10 @@ class RegisterServiceUtility
                     'className' => AutomaticAuthenticationService::class,
                 ]
             );
-            /** @noinspection UnsupportedStringOffsetOperationsInspection */
+
+            /* @phpstan-ignore-next-line */
             $GLOBALS['TYPO3_CONF_VARS']['SVCONF']['auth']['setup']['BE_alwaysFetchUser'] = true;
-            /** @noinspection UnsupportedStringOffsetOperationsInspection */
+            /* @phpstan-ignore-next-line */
             $GLOBALS['TYPO3_CONF_VARS']['SVCONF']['auth']['setup']['BE_alwaysAuthUser'] = true;
         }
     }
@@ -82,7 +83,8 @@ class RegisterServiceUtility
      */
     protected static function isDisableCookieSet(): bool
     {
-        return isset($GLOBALS['_COOKIE'][static::DISABLE_AUTO_LOGIN_COOKIE_NAME])
+        return is_array($GLOBALS['_COOKIE'] ?? null)
+            && isset($GLOBALS['_COOKIE'][static::DISABLE_AUTO_LOGIN_COOKIE_NAME])
             && $GLOBALS['_COOKIE'][static::DISABLE_AUTO_LOGIN_COOKIE_NAME] === static::DISABLE_AUTO_LOGIN_COOKIE_VALUE;
     }
 

--- a/src/Utility/RegisterServiceUtility.php
+++ b/src/Utility/RegisterServiceUtility.php
@@ -39,11 +39,6 @@ class RegisterServiceUtility
      */
     protected const DISABLE_AUTO_LOGIN_COOKIE_VALUE = 'disable';
 
-    protected static function getLogger(): Logger
-    {
-        return GeneralUtility::makeInstance(LogManager::class)->getLogger(__CLASS__);
-    }
-
     /**
      * @throws NotAllowedException
      */
@@ -84,11 +79,15 @@ class RegisterServiceUtility
 
     /**
      * Checks whether the cookie to disable autologin is set
-     *
-     * @return bool
      */
     protected static function isDisableCookieSet(): bool
     {
-        return isset($GLOBALS['_COOKIE'][static::DISABLE_AUTO_LOGIN_COOKIE_NAME]) && $GLOBALS['_COOKIE'][static::DISABLE_AUTO_LOGIN_COOKIE_NAME] === static::DISABLE_AUTO_LOGIN_COOKIE_VALUE;
+        return isset($GLOBALS['_COOKIE'][static::DISABLE_AUTO_LOGIN_COOKIE_NAME])
+            && $GLOBALS['_COOKIE'][static::DISABLE_AUTO_LOGIN_COOKIE_NAME] === static::DISABLE_AUTO_LOGIN_COOKIE_VALUE;
+    }
+
+    protected static function getLogger(): Logger
+    {
+        return GeneralUtility::makeInstance(LogManager::class)->getLogger(self::class);
     }
 }

--- a/tests/Functional/Fixtures/be_users_legacy.csv
+++ b/tests/Functional/Fixtures/be_users_legacy.csv
@@ -1,3 +1,0 @@
-"be_users"
-,"uid","pid","username","deleted","disableIPlock"
-,1,0,dummy,0,1

--- a/tests/Functional/Service/AutomaticAuthenticationServiceTest.php
+++ b/tests/Functional/Service/AutomaticAuthenticationServiceTest.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Undkonsorten\TYPO3AutoLogin\Tests\Functional\Service;
 
 /*

--- a/tests/Functional/Service/AutomaticAuthenticationServiceTest.php
+++ b/tests/Functional/Service/AutomaticAuthenticationServiceTest.php
@@ -60,6 +60,8 @@ class AutomaticAuthenticationServiceTest extends FunctionalTestCase
     public function getUserReturnsUserRecordAssociatedWithAutologinUsername(): void
     {
         $record = $this->subject->getUser();
+
+        self::assertIsArray($record);
         self::assertEquals(1, $record['uid']);
         self::assertEquals('dummy', $record['username']);
     }
@@ -78,7 +80,6 @@ class AutomaticAuthenticationServiceTest extends FunctionalTestCase
      */
     public function authUserReturnsCorrectAuthenticationState(): void
     {
-        $record = $this->subject->getUser();
-        self::assertEquals(200, $this->subject->authUser($record));
+        self::assertEquals(200, $this->subject->authUser());
     }
 }

--- a/tests/Functional/Service/AutomaticAuthenticationServiceTest.php
+++ b/tests/Functional/Service/AutomaticAuthenticationServiceTest.php
@@ -67,10 +67,10 @@ class AutomaticAuthenticationServiceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function getUserReturnsNullIfSwitchUserIsActive(): void
+    public function getUserReturnsFalseIfSwitchUserIsActive(): void
     {
         $this->backendUser->getSession()->set('backuserid', 1);
-        self::assertNull($this->subject->getUser());
+        self::assertFalse($this->subject->getUser());
     }
 
     /**

--- a/tests/Functional/Service/AutomaticAuthenticationServiceTest.php
+++ b/tests/Functional/Service/AutomaticAuthenticationServiceTest.php
@@ -22,7 +22,6 @@ namespace Undkonsorten\TYPO3AutoLogin\Tests\Functional\Service;
  */
 
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 use Undkonsorten\TYPO3AutoLogin\Service\AutomaticAuthenticationService;
 
@@ -34,15 +33,8 @@ use Undkonsorten\TYPO3AutoLogin\Service\AutomaticAuthenticationService;
  */
 class AutomaticAuthenticationServiceTest extends FunctionalTestCase
 {
-    /**
-     * @var AutomaticAuthenticationService
-     */
-    protected $subject;
-
-    /**
-     * @var BackendUserAuthentication
-     */
-    protected $backendUser;
+    protected AutomaticAuthenticationService $subject;
+    protected BackendUserAuthentication $backendUser;
 
     protected function setUp(): void
     {
@@ -51,12 +43,8 @@ class AutomaticAuthenticationServiceTest extends FunctionalTestCase
         // Provide environment variable for authentication process
         putenv(AutomaticAuthenticationService::TYPO3_AUTOLOGIN_USERNAME_ENVVAR . '=dummy');
 
-        // Import user record (TYPO3 < 11 provides an additional "disableIPlock" column)
-        if ($this->providesNewSessionHandling()) {
-            $this->importCSVDataSet(__DIR__ . '/../Fixtures/be_users.csv');
-        } else {
-            $this->importCSVDataSet(__DIR__ . '/../Fixtures/be_users_legacy.csv');
-        }
+        // Import user record
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/be_users.csv');
 
         // Build subject
         $this->subject = new AutomaticAuthenticationService();
@@ -79,13 +67,8 @@ class AutomaticAuthenticationServiceTest extends FunctionalTestCase
      */
     public function getUserReturnsNullIfSwitchUserIsActive(): void
     {
-        if ($this->providesNewSessionHandling()) {
-            $this->backendUser->getSession()->set('backuserid', 1);
-            self::assertNull($this->subject->getUser(), 'new session handling (TYPO3 >= 11)');
-        } else {
-            $this->subject->authInfo = ['userSession' => ['ses_backuserid' => 1]];
-            self::assertNull($this->subject->getUser(), 'old session handling (TYPO3 < 11)');
-        }
+        $this->backendUser->getSession()->set('backuserid', 1);
+        self::assertNull($this->subject->getUser());
     }
 
     /**
@@ -95,10 +78,5 @@ class AutomaticAuthenticationServiceTest extends FunctionalTestCase
     {
         $record = $this->subject->getUser();
         self::assertEquals(200, $this->subject->authUser($record));
-    }
-
-    private function providesNewSessionHandling(): bool
-    {
-        return (new Typo3Version())->getMajorVersion() >= 11;
     }
 }

--- a/tests/Stubs/AbstractAuthenticationService.stub
+++ b/tests/Stubs/AbstractAuthenticationService.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace TYPO3\CMS\Core\Authentication;
+
+/**
+ * This file can be removed once https://review.typo3.org/c/Packages/TYPO3.CMS/+/77385 is released.
+ */
+class AbstractAuthenticationService
+{
+    /**
+     * Get a user from DB by username
+     *
+     * @param string $username User name
+     * @param string $extraWhere Additional WHERE clause: " AND ...
+     * @param array<string, string>|string $dbUserSetup User db table definition, or empty string for $this->db_user
+     * @return array<string, mixed>|false User array or FALSE
+     */
+    public function fetchUserRecord($username, $extraWhere = '', $dbUserSetup = '') {}
+}

--- a/tests/Unit/Utility/RegisterServiceUtilityTest.php
+++ b/tests/Unit/Utility/RegisterServiceUtilityTest.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Undkonsorten\TYPO3AutoLogin\Tests\Unit\Utility;
 
 /*

--- a/tests/Unit/Utility/RegisterServiceUtilityTest.php
+++ b/tests/Unit/Utility/RegisterServiceUtilityTest.php
@@ -43,13 +43,11 @@ use Undkonsorten\TYPO3AutoLogin\Utility\RegisterServiceUtility;
  */
 class RegisterServiceUtilityTest extends UnitTestCase
 {
+    protected bool $backupEnvironment = true;
+    protected bool $resetSingletonInstances = true;
+
     protected function setUp(): void
     {
-        // @todo Should be moved back to property declaration once TF v7
-        //       is required as minimal installable version
-        $this->backupEnvironment = true;
-        $this->resetSingletonInstances = true;
-
         parent::setUp();
 
         // Provide environment variable for authentication process


### PR DESCRIPTION
This PR

- [x] drops support for PHP < 8.0
- [x] drops support for TYPO3 < 11.0
- [x] integrates TYPO3 Rector for automatic code migration
- [x] integrates and applies TYPO3 coding standards
- [x] integrates and performs normalization of `composer.json`
- [x] integrates PHPStan for static code analysis
- [x] introduces a CGL workflow