### PR TITLE
[TASK] Run test workflow with TYPO3 v12.3

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,11 +16,11 @@ jobs:
       fail-fast: false
       matrix:
         php-version: ["8.0", "8.1", "8.2"]
-        typo3-version: ["11.5", "12.2"]
+        typo3-version: ["11.5", "12.3"]
         dependencies: ["highest", "lowest"]
         exclude:
           - php-version: "8.0"
-            typo3-version: "12.2"
+            typo3-version: "12.3"
     services:
       mysql:
         image: mysql:5.7


### PR DESCRIPTION
TYPO3 v12.3 was released some minutes ago. The test workflow now runs with the latest stable version.