### PR TITLE
[TASK] Allow typo3/testing-framework v8

### DIFF
--- a/build/cgl/phpstan.neon
+++ b/build/cgl/phpstan.neon
@@ -2,8 +2,6 @@ includes:
 	- ../../.build/vendor/phpstan/phpstan/conf/bleedingEdge.neon
 parameters:
 	level: max
-	bootstrapFiles:
-		- ../../.build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php
 	paths:
 		- ../../src
 		- ../../tests

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		"ssch/typo3-rector": "^1.1",
 		"typo3/coding-standards": "^0.7",
 		"typo3/minimal": "^11.0 || ^12.0",
-		"typo3/testing-framework": "^7.0@dev"
+		"typo3/testing-framework": "^7.0.2 || ^8.0"
 	},
 	"autoload": {
 		"psr-4": {
@@ -55,16 +55,6 @@
 		}
 	},
 	"scripts": {
-		"post-autoload-dump": [
-			"# The following lines can be removed once TF v7 is stable",
-			"mkdir -p .build/web/typo3/sysext",
-			"[ -d .build/web/typo3/sysext/backend ] || ln -sfn ../../../vendor/typo3/cms-backend .build/web/typo3/sysext/backend",
-			"[ -d .build/web/typo3/sysext/core ] || ln -sfn ../../../vendor/typo3/cms-core .build/web/typo3/sysext/core",
-			"[ -d .build/web/typo3/sysext/extbase ] || ln -sfn ../../../vendor/typo3/cms-extbase .build/web/typo3/sysext/extbase",
-			"[ -d .build/web/typo3/sysext/fluid ] || ln -sfn ../../../vendor/typo3/cms-fluid .build/web/typo3/sysext/fluid",
-			"[ -d .build/web/typo3/sysext/frontend ] || ln -sfn ../../../vendor/typo3/cms-frontend .build/web/typo3/sysext/frontend",
-			"[ -d .build/web/typo3/sysext/install ] || ln -sfn ../../../vendor/typo3/cms-install .build/web/typo3/sysext/install"
-		],
 		"lint": [
 			"@lint:composer",
 			"@lint:editorconfig",

--- a/src/Exception/NotAllowedException.php
+++ b/src/Exception/NotAllowedException.php
@@ -17,6 +17,4 @@ namespace Undkonsorten\TYPO3AutoLogin\Exception;
  * Class NotAllowedException
  * @author Felix Althaus <felix.althaus@undkonsorten.com>
  */
-class NotAllowedException extends \Exception
-{
-}
+class NotAllowedException extends \Exception {}


### PR DESCRIPTION
This PR switches to stable versions 7 and 8 of `typo3/testing-framework`.